### PR TITLE
Replace missing PF4 variables #1

### DIFF
--- a/src/sass/chrome.scss
+++ b/src/sass/chrome.scss
@@ -57,6 +57,16 @@ aside {
   }
 }
 
+// temp replacement for non-working PF4 variables
+.pf-c-page__main-section {
+  // padding: var(--pf-c-page__main-section--PaddingTop) var(--pf-c-page__main-section--PaddingRight) var(--pf-c-page__main-section--PaddingBottom) var(--pf-c-page__main-section--PaddingLeft);
+  padding: 24px;
+}
+.pf-c-page__main-section.pf-m-light {
+  // --pf-c-page__main-section--BackgroundColor: var(--pf-c-page__main-section--m-light--BackgroundColor);
+  --pf-c-page__main-section--BackgroundColor: #fff;
+}
+
 // Landing page logout alert
 .pf-v5-c-alert.chr-c-alert {
   position: absolute;


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-27741

PF4 variables are scoped to `pf-c-page` but Chrome is rendering `pf-v5-c-page` - affecting RBAC, Sources, Authentication Factors, etc...

Old
<img width="1375" alt="Screenshot 2023-08-16 at 5 22 24 PM" src="https://github.com/Hyperkid123/insights-chrome/assets/1287144/dbe195c0-e6c8-4cf9-bff7-f0b21982a639">

New
<img width="1377" alt="Screenshot 2023-08-16 at 5 22 05 PM" src="https://github.com/Hyperkid123/insights-chrome/assets/1287144/de955e7e-58ce-4e0a-abda-51d74a63abb6">
